### PR TITLE
Add Delete Confirmations and Accordion Sections Using Stimulus

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,2 @@
 import "@hotwired/turbo-rails"
 import "controllers"
-
-import Rails from "@rails/ujs"
-Rails.start()

--- a/app/javascript/controllers/accordion_controller.js
+++ b/app/javascript/controllers/accordion_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel","icon"]
+
+  toggle() {
+    const hidden = this.panelTarget.toggleAttribute("hidden")
+    const expanded = !hidden
+    this.iconTarget.style.transform = expanded ? "rotate(180deg)" : ""
+  }
+}

--- a/app/javascript/controllers/confirm_controller.js
+++ b/app/javascript/controllers/confirm_controller.js
@@ -3,13 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = { message: String }
 
-  connect() { console.log("confirm#connect", this.element) }
-
   confirm(event) {
-    console.log('anything?')
-    console.log(event)
     if (!window.confirm(this.messageValue)) {
-      console.log(this.messageValue)
       event.preventDefault()
     }
   }

--- a/app/javascript/controllers/confirm_controller.js
+++ b/app/javascript/controllers/confirm_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { message: String }
+
+  connect() { console.log("confirm#connect", this.element) }
+
+  confirm(event) {
+    console.log('anything?')
+    console.log(event)
+    if (!window.confirm(this.messageValue)) {
+      console.log(this.messageValue)
+      event.preventDefault()
+    }
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/views/accommodations/show.html.erb
+++ b/app/views/accommodations/show.html.erb
@@ -33,7 +33,7 @@
                     data: {
                       controller: "confirm",
                       action: "submit->confirm#confirm",
-                      confirm_message_value: "Are you sure you want to delete this?"
+                      confirm_message_value: "Are you sure you want to delete this template?"
                     }
                   },
                   class: "inline-block rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700" %>

--- a/app/views/accommodations/show.html.erb
+++ b/app/views/accommodations/show.html.erb
@@ -29,7 +29,13 @@
     <%= button_to "Delete",
                   accommodation_path(@accommodation),
                   method: :delete,
-                  data: { confirm: "Are you sure?" },
+                  form: {
+                    data: {
+                      controller: "confirm",
+                      action: "submit->confirm#confirm",
+                      confirm_message_value: "Are you sure you want to delete this?"
+                    }
+                  },
                   class: "inline-block rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700" %>
   <% end %>
 </div>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -36,7 +36,7 @@
                     data: {
                       controller: "confirm",
                       action: "submit->confirm#confirm",
-                      confirm_message_value: "Are you sure you want to delete this?"
+                      confirm_message_value: "Are you sure you want to delete this template?"
                     }
                   },
                   class: "inline-block rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700" %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -32,7 +32,13 @@
     <%= button_to "Delete",
                   goal_path(@goal),
                   method: :delete,
-                  data: { confirm: "Are you sure?" },
+                  form: {
+                    data: {
+                      controller: "confirm",
+                      action: "submit->confirm#confirm",
+                      confirm_message_value: "Are you sure you want to delete this?"
+                    }
+                  },
                   class: "inline-block rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700" %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= javascript_import_module_tag "application" %>
   </head>
   <body class="min-h-screen bg-slate-50 text-slate-800">
     <header class="bg-white border-b">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,5 +29,6 @@
       <%= render "shared/flash" %>
       <%= yield %>
     </main>
+    <span class="hidden rotate-180"></span>
   </body>
 </html>

--- a/app/views/student_accommodations/show.html.erb
+++ b/app/views/student_accommodations/show.html.erb
@@ -34,7 +34,13 @@
     <%= button_to "Remove Accommodation",
           student_student_accommodation_path(@student, @student_accommodation),
           method: :delete,
-          data: { confirm: "Are you sure?" },
+          form: {
+                      data: {
+                        controller: "confirm",
+                        action: "submit->confirm#confirm",
+                        confirm_message_value: "Are you sure you want to delete this accommodation?"
+                      }
+                    },
           class: "inline-flex items-center rounded-md bg-red-600 px-4 py-2 text-white text-sm font-medium hover:bg-red-700" %>
   <% end %>
 

--- a/app/views/student_goals/show.html.erb
+++ b/app/views/student_goals/show.html.erb
@@ -90,7 +90,13 @@
               <%= button_to "Delete",
                   student_student_goal_progress_entry_path(@student, @student_goal, entry),
                   method: :delete,
-                  data: { confirm: "Are you sure?" },
+                  form: {
+                      data: {
+                        controller: "confirm",
+                        action: "submit->confirm#confirm",
+                        confirm_message_value: "Are you sure you want to delete this entry?"
+                      }
+                    },
                   class: "ml-4 inline-flex items-center px-3 py-1 text-sm text-white bg-red-600 rounded-md hover:bg-red-500" %>
             <% end %>
           </div>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -34,7 +34,7 @@
       <svg data-accordion-target="icon"
        viewBox="0 0 24 24" fill="none" stroke="currentColor"
        class="w-4 h-4 shrink-0 grow-0 basis-4 ml-2 transition-transform duration-200 origin-center"
-       style="width:1.1rem;height:1.1rem;margin-left:1rem;">
+       style="width:1.1rem;height:1.1rem;margin-left:1rem;margin-right:1rem;">
         <path d="M19.5 8.25l-7.5 7.5-7.5-7.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
 
@@ -82,7 +82,7 @@
       <svg data-accordion-target="icon"
        viewBox="0 0 24 24" fill="none" stroke="currentColor"
        class="w-4 h-4 shrink-0 grow-0 basis-4 ml-2 transition-transform duration-200 origin-center"
-       style="width:1.1rem;height:1.1rem;margin-left:1rem;">
+       style="width:1.1rem;height:1.1rem;margin-left:1rem;margin-right:1rem;">
         <path d="M19.5 8.25l-7.5 7.5-7.5-7.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
 

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -26,7 +26,7 @@
 
 <% if policy(Goal).show? %>
   <div data-controller="accordion"
-     class="rounded-md border border-slate-200 bg-white w-full">
+     class="rounded-md border border-slate-200 bg-white w-full p-4">
     <button
       data-action="click->accordion#toggle"
       class="flex items-center gap-2 w-full px-2 py-1 m-1 bg-slate-200 hover:bg-slate-300 leading-none"
@@ -69,34 +69,51 @@
       <% end %>
     </div>
   </div>
-  <h2 class="mt-10 text-xl font-semibold"></h2>
 
 <% end %>
 
 <% if policy(Accommodation).new? %>
-  <h2 class="mt-10 text-xl font-semibold">Accommodation Templates</h2>
-  <div class="mt-3 grid gap-3 md:grid-cols-2">
-    <% if @accommodations.any? %>
-      <% @accommodations.each do |a| %>
-        <div class="rounded-md border border-slate-200 bg-white p-4 shadow-sm hover:shadow-md transition">
-          <div>
-            <%= link_to a.name, a, class: "font-medium text-slate-800 hover:text-blue-600" %>
-            <span class="ml-2 text-xs rounded bg-slate-100 px-2 py-0.5 text-slate-600"><%= a.accommodation_type.humanize %></span>
-          </div>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="rounded-md border border-dashed border-slate-300 bg-white p-6 text-slate-500">
-        No accommodation templates yet.
-      </div>
-    <% end %>
-  </div>
+  <div data-controller="accordion"
+     class="rounded-md border border-slate-200 bg-white w-full p-4">
+    <button
+      data-action="click->accordion#toggle"
+      class="flex items-center gap-2 w-full px-2 py-1 m-1 bg-slate-200 hover:bg-slate-300 leading-none"
+      style="cursor:pointer;">
+      <svg data-accordion-target="icon"
+       viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       class="w-4 h-4 shrink-0 grow-0 basis-4 ml-2 transition-transform duration-200 origin-center"
+       style="width:1.1rem;height:1.1rem;margin-left:1rem;">
+        <path d="M19.5 8.25l-7.5 7.5-7.5-7.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
 
-  <% if policy(Accommodation).new? %>
-    <div class="mt-3">
-      <%= link_to "Add Accommodation Template",
+      <span class="flex-1 min-w-0 whitespace-nowrap text-xl font-semibold">Accommodation Templates</span>
+    </button>
+
+    <div data-accordion-target="panel" hidden class="p-4 border-t">
+
+      <div class="mt-3 grid gap-3 md:grid-cols-2">
+        <% if @accommodations.any? %>
+          <% @accommodations.each do |a| %>
+            <div class="rounded-md border border-slate-200 bg-white p-4 shadow-sm hover:shadow-md transition">
+              <div>
+                <%= link_to a.name, a, class: "font-medium text-slate-800 hover:text-blue-600" %>
+                <span class="ml-2 text-xs rounded bg-slate-100 px-2 py-0.5 text-slate-600"><%= a.accommodation_type.humanize %></span>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="rounded-md border border-dashed border-slate-300 bg-white p-6 text-slate-500">
+            No accommodation templates yet.
+          </div>
+        <% end %>
+      </div>
+
+      <% if policy(Accommodation).new? %>
+        <div class="mt-4">
+          <%= link_to "Add Accommodation Template",
                   new_accommodation_path,
                   class: "inline-flex items-center rounded-md bg-slate-800 px-4 py-2 text-white text-sm font-semibold hover:bg-slate-700" %>
+        </div>
+      <% end %>
     </div>
   <% end %>
-<% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -24,33 +24,53 @@
   </div>
 <% end %>
 
-<% if policy(Goal).new? %>
-  <h2 class="mt-10 text-xl font-semibold">Goal Templates</h2>
-  <div class="mt-3 grid gap-3 md:grid-cols-2">
-    <% if @goals.any? %>
-      <% @goals.each do |g| %>
-        <div class="rounded-md border border-slate-200 bg-white p-4 shadow-sm hover:shadow-md transition">
-          <div>
-            <%= link_to g.name, g, class: "font-medium text-slate-800 hover:text-blue-600" %>
-            <span class="ml-2 text-xs rounded bg-slate-100 px-2 py-0.5 text-slate-600"><%= g.category %></span>
-            <% unless g.active? %><span class="ml-2 text-xs text-red-600">inactive</span><% end %>
-          </div>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="rounded-md border border-dashed border-slate-300 bg-white p-6 text-slate-500">
-        No goal templates yet.
-      </div>
-    <% end %>
-  </div>
+<% if policy(Goal).show? %>
+  <div data-controller="accordion"
+     class="rounded-md border border-slate-200 bg-white w-full">
+    <button
+      data-action="click->accordion#toggle"
+      class="flex items-center gap-2 w-full px-2 py-1 m-1 bg-slate-200 hover:bg-slate-300 leading-none"
+      style="cursor:pointer;">
+      <svg data-accordion-target="icon"
+       viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       class="w-4 h-4 shrink-0 grow-0 basis-4 ml-2 transition-transform duration-200 origin-center"
+       style="width:1.1rem;height:1.1rem;margin-left:1rem;">
+        <path d="M19.5 8.25l-7.5 7.5-7.5-7.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
 
-  <% if policy(Goal).new? %>
-    <div class="mt-3">
-      <%= link_to "Add Goal Template",
+      <span class="flex-1 min-w-0 whitespace-nowrap text-xl font-semibold">Goal Templates</span>
+    </button>
+
+    <div data-accordion-target="panel" hidden class="p-4 border-t">
+      <div class="mt-3 grid gap-3 md:grid-cols-2">
+        <% if @goals.any? %>
+          <% @goals.each do |g| %>
+            <div class="rounded-md border border-slate-200 bg-white p-4 shadow-sm hover:shadow-md transition">
+              <div>
+                <%= link_to g.name, g, class: "font-medium text-slate-800 hover:text-blue-600" %>
+                <span class="ml-2 text-xs rounded bg-slate-100 px-2 py-0.5 text-slate-600"><%= g.category %></span>
+                <% unless g.active? %><span class="ml-2 text-xs text-red-600">inactive</span><% end %>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="rounded-md border border-dashed border-slate-300 bg-white p-6 text-slate-500">
+            No goal templates yet.
+          </div>
+        <% end %>
+      </div>
+
+      <% if policy(Goal).create? %>
+        <div class="mt-4">
+          <%= link_to "Add Goal Template",
                   new_goal_path,
                   class: "inline-flex items-center rounded-md bg-slate-800 px-4 py-2 text-white text-sm font-semibold hover:bg-slate-700" %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
+  <h2 class="mt-10 text-xl font-semibold"></h2>
+
 <% end %>
 
 <% if policy(Accommodation).new? %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -43,7 +43,13 @@
               <%= button_to "Delete",
                     student_student_goal_path(@student, sg),
                     method: :delete,
-                    data: { confirm: "Are you sure?" },
+                    form: {
+                      data: {
+                        controller: "confirm",
+                        action: "submit->confirm#confirm",
+                        confirm_message_value: "Are you sure you want to delete this goal?"
+                      }
+                    },
                     class: "rounded-md bg-red-50 px-3 py-1.5 text-sm text-red-700 hover:bg-red-100" %>
             <% end %>
           </div>
@@ -70,7 +76,13 @@
             <%= button_to "Delete",
                 student_student_accommodation_path(@student, sa),
                 method: :delete,
-                data: { confirm: "Are you sure?" },
+                form: {
+                      data: {
+                        controller: "confirm",
+                        action: "submit->confirm#confirm",
+                        confirm_message_value: "Are you sure you want to delete this accommodation?"
+                      }
+                    },
                 class: "rounded-md bg-red-50 px-3 py-1.5 text-sm text-red-700 hover:bg-red-100" %>
           <% end %>
         </li>
@@ -94,17 +106,14 @@
       <%= button_to "Delete #{@student.first_name}",
           student_path(@student),
           method: :delete,
-          form: { data: { dlt_btn: true } },
+          form: {
+                    data: {
+                      controller: "confirm",
+                      action: "submit->confirm#confirm",
+                      confirm_message_value: "Are you sure you want to delete this?"
+                    }
+                  },
           class: "inline-flex items-center rounded-lg bg-red-600 px-3 py-1.5 text-white text-sm hover:bg-red-700" %>
     <% end %>
   </section>
 </div>
-
-<script>
-  let dlt_btn = document.querySelector('[data-dlt-btn]')
-  dlt_btn.addEventListener('click', function(e) {
-    e.preventDefault();
-    confirm("Are you sure?") ? dlt_btn.submit() : console.log('test')
-
-  })
-</script>


### PR DESCRIPTION
Previously, all delete buttons in the application were ignoring turbo delete confirmations - possibly due to some conflict between it and Pundit/Devise. Now, all delete buttons prompt a custom message confirmation so the user can't accidentally/easily delete data.

This PR implements a 'confirm_controller' using Stimulus, which calls a confirm method within the controller each time a delete button is 'submitted' since the Rails button_to helper creates a form element. It also introduces an additional accordion controller, which allows expandable/collapsible sections on the Students#index root page.

https://github.com/user-attachments/assets/cfe4f30b-9c83-4a53-bc86-2af2c3e2278a